### PR TITLE
Switch away from deprecated setup-android 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
+name: CI
+on:
+  push:
+  pull_request:
+
 - name: "Imdb Example"
-  uses: msfjarvis/setup-android@1.0
-  with:
-    entrypoint: ./ImdbExample/gradlew
-    args: dependencies spotlessApply detekt assembleDebug
+  run: |
+    cd ImdbExample
+    ./gradlew dependencies spotlessApply detekt assembleDebug


### PR DESCRIPTION
I am in the process of deprecating setup-android as GitHub Actions now ships default containers with everything that's needed.
﻿﻿